### PR TITLE
use 12.04.5 build of ubuntu base image instead of latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:12.04.5
 MAINTAINER Martin Yrjölä <martin.yrjola@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
currently the 14.x builds of the ubuntu image do not with with this docker container due to dependency resolution issues.

```
Step 12 : RUN apt-get install -y build-essential libacl1-dev libattr1-dev       libblkid-dev libgnutls-dev libreadline-dev python-dev libpam0g-dev       python-dnspython gdb pkg-config libpopt-dev libldap2-dev       dnsutils libbsd-dev attr krb5-user docbook-xsl libcups2-dev acl python-xattr
 ---> Running in fc26f9e287ea
Reading package lists...
Building dependency tree...
Reading state information...
dnsutils is already the newest version.
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 krb5-user : Depends: libkrb5-3 (= 1.12+dfsg-2ubuntu4.2) but 1.12+dfsg-2ubuntu5 is to be installed
E: Unable to correct problems, you have held broken packages.
Removing intermediate container fc26f9e287ea
2014/11/26 00:20:59 The command [/bin/sh -c apt-get install -y build-essential libacl1-dev libattr1-dev       libblkid-dev libgnutls-dev libreadline-dev python-dev libpam0g-dev       python-dnspython gdb pkg-config libpopt-dev libldap2-dev       dnsutils libbsd-dev attr krb5-user docbook-xsl libcups2-dev acl python-xattr] returned a non-zero code: 100
```

Moving to a 12.x version of the ubuntu image fixes the issue
